### PR TITLE
Try to fetch xcodebuild path only on 'darwin' devices

### DIFF
--- a/envinfo.js
+++ b/envinfo.js
@@ -14,8 +14,8 @@ function run(cmd) {
 
 function getXcodeVersion() {
   var xcodeVersion;
-  var xcodePath = which.sync('xcodebuild');
   if (process.platform === 'darwin') {
+    var xcodePath = which.sync('xcodebuild');
     try {
       xcodeVersion = xcodePath && run(xcodePath + ' -version').split('\n').join(' ');
     } catch (err) {


### PR DESCRIPTION
## Description
Try to fetch xcodebuild path only when `process.platform` returns `darwin` value

Fix for https://github.com/tabrindle/envinfo/issues/3