### PR TITLE
refactor: use yaml as default table, modularize custom logic in formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "object.entries": "^1.0.4",
     "object.values": "^1.0.4",
     "os-name": "^2.0.1",
-    "which": "^1.2.14"
+    "which": "^1.2.14",
+    "yamlify-object": "^0.4.5"
   },
   "devDependencies": {
     "eslint": "^4.10.0",

--- a/src/envinfo.js
+++ b/src/envinfo.js
@@ -60,7 +60,7 @@ module.exports.envinfo = function print(options) {
   const formatter = (() => {
     if (options.json) return formatters.json;
     if (options.markdown) return formatters.markdown;
-    return formatters.table;
+    return formatters.yaml;
   })();
   const formatted = formatter(data, { console: false });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,9 @@ function toReadableBytes(bytes) {
   );
 }
 
+const isObject = val => typeof val === 'object' && !Array.isArray(val);
+const pipe = fns => x => fns.reduce((v, f) => f(v), x);
+
 function requireJson(filePath) {
   var packageJson;
   if (fs.existsSync(filePath)) {
@@ -45,10 +48,15 @@ function getPackageJsonByPath(filePath) {
   return this.requireJson(path.join(process.cwd(), filePath));
 }
 
+const noop = d => d;
+
 module.exports = {
   run: run,
   getPackageJsonByName: getPackageJsonByName,
   getPackageJsonByPath: getPackageJsonByPath,
+  isObject: isObject,
+  noop: noop,
+  pipe: pipe,
   requireJson: requireJson,
   toReadableBytes: toReadableBytes,
   uniq: uniq,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,10 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yamlify-object@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/yamlify-object/-/yamlify-object-0.4.5.tgz#88291c64428d4aaf452141aaba6bda030d848f6c"
+
 yargs-parser@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"


### PR DESCRIPTION
The custom formatters were causing me pain. 

Problem 1 is that they were custom. I was traversing the data structure as if it couldn't change. Guess what? It did. 🤦‍♂️ 

Problem 2 is that they weren't really extensible. The refactor is much more functional and creates a framework for creating custom reformatters, and will allow for future formats to be more easily added. Now there is a clean function that can remove `N/A` or anything else we want, easily changed by options. There's also a custom formatter for terminal formatting (underline, bold etc)

Sorta Problem 3 the custom table I was creating was my own crappy invention. It wasn't too far from how YAML looks, so I made YAML the default. Interoperability between JSON and yaml make conversion easier. 