### PR TITLE
feat: add elixir to Languages

### DIFF
--- a/src/envinfo.js
+++ b/src/envinfo.js
@@ -20,7 +20,7 @@ const capabilities = {
   Binaries: ['Node', 'Yarn', 'npm', 'Watchman', 'Docker', 'Homebrew'],
   SDKs: ['iOS', 'Android'],
   IDEs: ['Android Studio', 'Atom', 'VSCode', 'Sublime Text', 'Xcode'],
-  Languages: ['Bash', 'Go', 'PHP', 'Python', 'Ruby'],
+  Languages: ['Bash', 'Go', 'Elixir', 'PHP', 'Python', 'Ruby'],
   Browsers: [
     'Chrome',
     'Chrome Canary',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -199,6 +199,16 @@ function getDockerVersion() {
   return dockerVersion;
 }
 
+function getElixirVersion() {
+  var elixirVersion;
+  try {
+    elixirVersion = /[Elixir]+\s([\d|.]+)/g.exec(utils.run('elixir --version'))[1];
+  } catch (error) {
+    elixirVersion = 'Not Found';
+  }
+  return elixirVersion;
+}
+
 function getFreeMemory() {
   return utils.toReadableBytes(os.freemem());
 }
@@ -430,6 +440,7 @@ module.exports = Object.assign(packages, {
   getCPUInfo: getCPUInfo,
   getDarwinApplicationVersion: getDarwinApplicationVersion,
   getDockerVersion: getDockerVersion,
+  getElixirVersion: getElixirVersion,
   getFreeMemory: getFreeMemory,
   getGoVersion: getGoVersion,
   getHomeBrewVersion: getHomeBrewVersion,

--- a/src/map.js
+++ b/src/map.js
@@ -42,6 +42,7 @@ module.exports = {
   // Languages
   bash: helpers.getBashVersion,
   go: helpers.getGoVersion,
+  elixir: helpers.getElixirVersion,
   php: helpers.getPhpVersion,
   python: helpers.getPythonVersion,
   ruby: helpers.getRubyVersion,


### PR DESCRIPTION
`envinfo --languages`

## Languages:
 - Bash: 4.4.12
 - Go: 1.9.3
 - Elixir: 1.6.2
 - PHP: 7.1.7
 - Python: 2.7.10
 - Ruby: 2.3.3p222