### PR TITLE
Fix sublime version without subl

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -205,7 +205,18 @@ module.exports = Object.assign({}, utils, packages, {
     return Promise.all([
       utils.run('subl --version').then(version => utils.findVersion(version, /\d+/)),
       utils.which('subl'),
-    ]).then(v => utils.determineFound('Sublime Text', v[0], v[1]));
+    ])
+      .then(v => {
+        if (v[0] === '' && macos) {
+          utils.log('trace', 'getSublimeTextInfo using plist');
+          return Promise.all([
+            utils.getDarwinApplicationVersion(utils.ideBundleIdentifiers['Sublime Text']),
+            NA,
+          ]);
+        }
+        return v;
+      })
+      .then(v => utils.determineFound('Sublime Text', v[0], v[1]));
   },
 
   getHomeBrewInfo: () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -100,9 +100,10 @@ module.exports = Object.assign({}, utils, packages, {
 
   getAtomInfo: () => {
     utils.log('trace', 'getAtomInfo');
-    return Promise.all([utils.getDarwinApplicationVersion('com.github.atom'), NA]).then(v =>
-      utils.determineFound('Atom', v[0], v[1])
-    );
+    return Promise.all([
+      utils.getDarwinApplicationVersion(utils.ideBundleIdentifiers.Atom),
+      NA,
+    ]).then(v => utils.determineFound('Atom', v[0], v[1]));
   },
 
   getMySQLInfo: () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,6 +86,11 @@ module.exports = {
     'Safari Technology Preview': 'com.apple.SafariTechnologyPreview',
   },
 
+  ideBundleIdentifiers: {
+    Atom: 'com.github.atom',
+    'Sublime Text': 'com.sublimetext.3',
+  },
+
   runSync: cmd => {
     return (
       childProcess


### PR DESCRIPTION
If the user doesn't have `subl` set up like I did :noob: envinfo would not register it.

<img width="618" alt="sublime-error" src="https://user-images.githubusercontent.com/1232725/39894340-215377b4-546c-11e8-9898-a31fead3a9af.png">
