### PR TITLE
feat: add title option for reports

### DIFF
--- a/__tests__/envinfo.test.js
+++ b/__tests__/envinfo.test.js
@@ -128,4 +128,34 @@ describe('Running the programmatic interface', () => {
       });
     });
   });
+
+  test('returns expected title in json', () => {
+    return envinfo
+      .run({ Binaries: ['Node'] }, { title: 'envinfo rocks!', json: true })
+      .then(data => {
+        return expect(JSON.parse(data)).toEqual({
+          'envinfo rocks!': {
+            Binaries: {
+              Node: {
+                version: '10.0.0',
+                path: '/usr/local/bin/node',
+              },
+            },
+          },
+        });
+      });
+  });
+
+  test('returns expected title in yaml', () => {
+    return envinfo.run({ Binaries: ['Node'] }, { title: 'envinfo rocks!' }).then(data => {
+      // prettier-ignore
+      return expect(data).toEqual(
+`
+  envinfo rocks!:
+    Binaries:
+      Node: 10.0.0 - /usr/local/bin/node
+`
+      );
+    });
+  });
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,6 +43,7 @@ if (argv.help || argv._.indexOf('help') > -1) {
     --console              Print to console (defaults to on for CLI usage, off for programmatic usage)
     --clipboard            Copy output to your system clipboard
     --showNotFound         Don't filter out values marked 'Not Found'
+    --title                Give your report a top level title ie 'Environment Report'
   `);
   process.exit(0);
 } else if (argv.version || argv.v || argv._.indexOf('version') > -1) {

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -162,6 +162,7 @@ function formatToYaml(data, options) {
     formatPackages,
     serializeArrays,
     serializeVersionsAndPaths,
+    options.title ? d => ({ [options.title]: d }) : utils.noop,
     yaml,
     options.console ? formatHeaders : utils.noop,
   ])(data, options);
@@ -176,6 +177,7 @@ function formatToMarkdown(data, options) {
     serializeVersionsAndPaths,
     yaml,
     markdown,
+    options.title ? d => `\n# ${options.title}${d}` : utils.noop,
   ])(data, options);
 }
 
@@ -183,7 +185,11 @@ function formatToJson(data, options) {
   utils.log('trace', 'formatToJson');
   if (!options) options = {};
 
-  data = utils.pipe([() => clean(data, options), json])(data);
+  data = utils.pipe([
+    () => clean(data, options),
+    options.title ? d => ({ [options.title]: d }) : utils.noop,
+    json,
+  ])(data);
   data = options.console ? `\n${data}\n` : data;
 
   return data;


### PR DESCRIPTION
Add a custom title option.

`envinfo --title 'env report 🎉'`

```
  env report 🎉:
    System:
      OS: macOS High Sierra 10.13
      CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
      Memory: 167.72 MB / 16.00 GB
```