### PR TITLE
fix ndk bug and add support for ENV ANDROID_NDK_HOME. Fixes #75.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ aliases:
   - &link-and-execute
     name: Run envinfo
     command: |
+      npm run build
       npm link
       envinfo
 
@@ -46,6 +47,15 @@ jobs:
       - run: npm install
       - run: npm run test
       - run: *link-and-execute
+  react-native-test:
+    working_directory: ~/repo
+    docker:
+      - image: reactnativecommunity/react-native-android
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run test
+      - run: *link-and-execute
 
 workflows:
   version: 2
@@ -54,3 +64,4 @@ workflows:
       - ubuntu-test
       - debian-test
       - centos-test
+      - react-native-test


### PR DESCRIPTION
Also add react native test image, output looks like this:

```
  System:
    OS: Linux 4.4 Debian GNU/Linux 9 (stretch) 9 (stretch)
    CPU: (36) x64 Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
    Memory: 1.10 GB / 68.70 GB
    Container: Yes
    Shell: 4.4.12 - /bin/bash
  Binaries:
    Node: 10.14.2 - /usr/bin/node
    Yarn: 1.12.3 - /usr/bin/yarn
    npm: 6.4.1 - /usr/bin/npm
  Utilities:
    Make: 4.1 - /usr/bin/make
    GCC: 6.3.0 - /usr/bin/gcc
    Git: 2.11.0 - /usr/bin/git
  SDKs:
    Android SDK:
      API Levels: 28
      Build Tools: 28.0.2
      System Images: android-19 | Google APIs ARM EABI v7a
      Android NDK: 17.2.4988734
  Languages:
    Bash: 4.4.12 - /bin/bash
    Java: 1.8.0 - /usr/bin/javac
    Perl: 5.24.1 - /usr/bin/perl
    Python: 2.7.13 - /usr/bin/python
  Databases:
    SQLite: 3.22.0 - /opt/android/platform-tools/sqlite3
```