### PR TITLE
fix: was checking rustup instead of rustc :facepalm:

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -68,6 +68,10 @@ const cases = {
     string: 'ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]',
     version: '2.3.7p456',
   },
+  rust: {
+    string: 'rustc 1.31.1 (b6c32da9b 2018-12-18)',
+    version: '1.31.1',
+  },
   sqlite: {
     string:
       '3.19.4 2017-08-18 19:28:12 605907e73adb4533b12d22be8422f17a8dc125b5c37bb391756a11fc3a8c4d10',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -644,7 +644,7 @@ module.exports = Object.assign({}, utils, packages, {
     if (macos || linux) {
       return Promise.all([
         utils.run('rustc --version').then(utils.findVersion),
-        utils.run('which rustc'),
+        utils.run('which rustc').then(utils.condensePath),
       ]).then(v => utils.determineFound('Rust', v[0], v[1]));
     }
     return Promise.resolve(['Rust', NA]);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -643,8 +643,8 @@ module.exports = Object.assign({}, utils, packages, {
     utils.log('trace', 'getRustInfo');
     if (macos || linux) {
       return Promise.all([
-        utils.run('rustup --version').then(utils.findVersion),
-        utils.run('which rustup'),
+        utils.run('rustc --version').then(utils.findVersion),
+        utils.run('which rustc'),
       ]).then(v => utils.determineFound('Rust', v[0], v[1]));
     }
     return Promise.resolve(['Rust', NA]);


### PR DESCRIPTION
New output:

```yaml
  System:
    OS: macOS 10.14.2
    CPU: (8) x64 Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
    Memory: 589.07 MB / 16.00 GB
    Shell: 5.3 - /bin/zsh
  Binaries:
    Node: 8.14.0 - ~/.nvm/versions/node/v8.14.0/bin/node
    Yarn: 1.12.3 - ~/.yarn/bin/yarn
    npm: 6.4.1 - ~/.nvm/versions/node/v8.14.0/bin/npm
    Watchman: 4.9.0 - /usr/local/bin/watchman
  Utilities:
    Make: 3.81 - /usr/bin/make
    GCC: 10.14. - /usr/bin/gcc
    Git: 2.20.0 - /usr/local/bin/git
  Servers:
    Apache: 2.4.34 - /usr/sbin/apachectl
  Virtualization:
    Docker: 18.09.0 - /usr/local/bin/docker
    VirtualBox: 5.2.20 - /usr/local/bin/vboxmanage
  SDKs:
    iOS SDK:
      Platforms: iOS 12.1, macOS 10.14, tvOS 12.1, watchOS 5.1
    Android SDK:
      API Levels: 28
      Build Tools: 28.0.3
      System Images: android-28 | Google Play Intel x86 Atom
  IDEs:
    Android Studio: 3.2 AI-181.5540.7.32.5056338
    Emacs: 22.1.1 - /usr/bin/emacs
    Nano: 2.0.6 - /usr/bin/nano
    VSCode: 1.30.1 - /usr/local/bin/code
    Vim: 8.0 - /usr/bin/vim
    Xcode: 10.1/10B61 - /usr/bin/xcodebuild
  Languages:
    Bash: 4.4.23 - /usr/local/bin/bash
    Go: 1.11.1 - /usr/local/bin/go
    Java: 1.8.0_192 - /usr/bin/javac
    Perl: 5.18.2 - /usr/bin/perl
    PHP: 7.1.19 - /usr/bin/php
    Python: 2.7.10 - /usr/bin/python
    Ruby: 2.3.7p456 - /usr/bin/ruby
    Rust: 1.31.1 - ~/.cargo/bin/rustc
  Databases:
    MySQL: 10.3.10 (MariaDB) - /usr/local/bin/mysql
    SQLite: 3.24.0 - /usr/bin/sqlite3
  Browsers:
    Chrome: 71.0.3578.98
    Firefox Developer Edition: 65.0
    Firefox Nightly: 61.0a1
    Safari: 12.0.2
```