### PR TITLE
chore: minor cleanup in envinfo.test and packages

### DIFF
--- a/__tests__/__snapshots__/envinfo.test.js.snap
+++ b/__tests__/__snapshots__/envinfo.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Running the programmatic interface filters out returned path values with N/A 1`] = `
+Object {
+  "Browsers": Object {
+    "Chrome": Object {
+      "version": "65.0.3325.181",
+    },
+  },
+}
+`;
+
 exports[`Running the programmatic interface filters out returned values with N/A 1`] = `
 Object {
   "Browsers": Object {

--- a/__tests__/envinfo.test.js
+++ b/__tests__/envinfo.test.js
@@ -74,11 +74,7 @@ describe('Running the programmatic interface', () => {
     );
 
     return envinfo.run({ Browsers: ['Chrome'] }, { json: true }).then(data => {
-      return expect(JSON.parse(data)).toEqual({
-        Browsers: {
-          Chrome: { version: '65.0.3325.181' },
-        },
-      });
+      expect(JSON.parse(data)).toMatchSnapshot();
     });
   });
 

--- a/src/packages.js
+++ b/src/packages.js
@@ -9,7 +9,7 @@ const parsePackagePath = packagePath => {
   return tree.split('/')[0];
 };
 
-function getnpmPackages(packages, options) {
+export function getnpmPackages(packages, options) {
   utils.log('trace', 'getnpmPackages');
   if (!options) options = {};
 
@@ -36,11 +36,7 @@ function getnpmPackages(packages, options) {
     utils
       .getPackageJsonByPath('package.json')
       .then(packageJson =>
-        Object.assign(
-          {},
-          (packageJson || {}).devDependencies || {},
-          (packageJson || {}).dependencies || {}
-        )
+        Object.assign({}, (packageJson || {}).devDependencies, (packageJson || {}).dependencies)
       )
       // determine which paths to get
       .then(packageJsonDependencies => {
@@ -48,27 +44,21 @@ function getnpmPackages(packages, options) {
         if (options.fullTree || options.duplicates || packageGlob) {
           return utils.getAllPackageJsonPaths(packageGlob);
         }
-        return Promise.resolve(
-          Object.keys(packageJsonDependencies || []).map(dep =>
-            path.join('node_modules', dep, 'package.json')
-          )
+        return Object.keys(packageJsonDependencies || []).map(dep =>
+          path.join('node_modules', dep, 'package.json')
         );
       })
       // filter by glob or selection
       .then(packageJsonPaths => {
         if ((packageGlob || typeof packages === 'boolean') && !options.fullTree) {
-          return Promise.resolve(
-            (packageJsonPaths || []).filter(p =>
-              Object.keys(tld || []).includes(parsePackagePath(p))
-            )
+          return (packageJsonPaths || []).filter(p =>
+            Object.keys(tld || []).includes(parsePackagePath(p))
           );
         }
         if (Array.isArray(packages)) {
-          return Promise.resolve(
-            (packageJsonPaths || []).filter(p => packages.includes(parsePackagePath(p)))
-          );
+          return (packageJsonPaths || []).filter(p => packages.includes(parsePackagePath(p)))
         }
-        return Promise.resolve(packageJsonPaths);
+        return packageJsonPaths;
       })
       .then(paths =>
         Promise.all([
@@ -116,7 +106,7 @@ function getnpmPackages(packages, options) {
   ]);
 }
 
-function getnpmGlobalPackages(packages, options) {
+export function getnpmGlobalPackages(packages, options) {
   utils.log('trace', 'getnpmGlobalPackages', packages);
 
   let packageGlob = null;
@@ -190,8 +180,3 @@ function getnpmGlobalPackages(packages, options) {
       }),
   ]);
 }
-
-module.exports = {
-  getnpmPackages: getnpmPackages,
-  getnpmGlobalPackages: getnpmGlobalPackages,
-};


### PR DESCRIPTION
Some more minor cleanup - I missed a snapshot in envinfo test and I noticed that babel / webpack is being used to build the dist files so using the `export` keywords felt a lot nicer!

Also in `src/packages.js` I noticed a lot of unnecessary `Promise.resolve` calls since the `.then` function will resolve whatever it returns to the next fn in the chain

This is all in my investigation of the issue I was having in #90 - and I think the [micromatch](https://npm.im/micromatch) package should do what is needed but I haven't quite gotten that working yet.