### PR TITLE
fix: use big glob for nyc preset

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -52,10 +52,7 @@ module.exports = {
   nyc: {
     System: ['OS', 'CPU', 'Memory'],
     Binaries: ['Node', 'Yarn', 'npm'],
-    npmPackages: ['*istanbul*', 'nyc', '*babel*', 'typescript', 'ts-node', 'source-map-support'],
-    options: {
-      showNotFound: true,
-    },
+    npmPackages: '/**/{*babel*,@babel/*/,*istanbul*,nyc,source-map-support,typescript,ts-node}',
   },
   webpack: {
     System: ['OS', 'CPU'],


### PR DESCRIPTION
Will output like this:

```
  System:
    OS: macOS 10.14.2
    CPU: (8) x64 Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
    Memory: 324.38 MB / 16.00 GB
  Binaries:
    Node: 8.15.0 - ~/.nvm/versions/node/v8.15.0/bin/node
    Yarn: 1.12.3 - ~/.yarn/bin/yarn
    npm: 6.4.1 - ~/.nvm/versions/node/v8.15.0/bin/npm
  npmPackages:
    @babel/core: ^7.2.2 => 7.2.2 
    @babel/plugin-proposal-optional-chaining: ^7.2.0 => 7.2.0 
    @babel/polyfill: ^7.2.5 => 7.2.5 
    @babel/preset-env: ^7.3.1 => 7.3.1 
    babel-core: 7.0.0-bridge.0 => 7.0.0-bridge.0 
    babel-eslint: ^10.0.1 => 10.0.1 
    babel-jest: 23.6.0 => 23.6.0 
    babel-loader: ^8.0.5 => 8.0.5 
    nyc: ^13.3.0 => 13.3.0 
```

Until we can add regex to npmPackages args, one big glob will have to do. No showNotFound option though :-/