### PR TITLE
add clang support.

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -90,6 +90,15 @@ http://www.gnu.org/licenses/.
       '3.19.4 2017-08-18 19:28:12 605907e73adb4533b12d22be8422f17a8dc125b5c37bb391756a11fc3a8c4d10',
     version: '3.19.4',
   },
+  clang: {
+    string: `clang version 7.0.0-3 (tags/RELEASE_700/final)
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/bin`,
+    regex: /([0-9].*) /,
+    index: 1,
+    version: '7.0.0-3',
+  },
   sublime: {
     regex: /\d+/,
     string: 'Sublime Text Build 3143',

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -28,10 +28,10 @@ module.exports = {
     return Promise.all([
       utils.run('clang --version').then(v => {
         if (utils.isMacOS) {
-          return v.match(/clang-(.*)\)/).groups[1];
+          return v.match(/clang-(.*)\)/)[1];
         }
 
-        return v.match(/([0-9].*) /).groups[1];
+        return v.match(/([0-9].*) /)[1];
       }),
       utils.which('clang'),
     ]).then(v => utils.determineFound('Clang', v[0], v[1]));

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -23,6 +23,20 @@ module.exports = {
     return Promise.resolve(['GCC', 'N/A']);
   },
 
+  getClangInfo: () => {
+    utils.log('trace', 'getClangInfo');
+    return Promise.all([
+      utils.run('clang --version').then(v => {
+        if (utils.isMacOS) {
+          return v.match(/clang-(.*)\)/).groups[1];
+        }
+
+        return v.match(/([0-9].*) /).groups[1];
+      }),
+      utils.which('clang'),
+    ]).then(v => utils.determineFound('Clang', v[0], v[1]));
+  },
+
   getGitInfo: () => {
     utils.log('trace', 'getGitInfo');
     if (utils.isMacOS || utils.isLinux) {

--- a/src/presets.js
+++ b/src/presets.js
@@ -2,7 +2,7 @@ module.exports = {
   defaults: {
     System: ['OS', 'CPU', 'Memory', 'Container', 'Shell'],
     Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-    Utilities: ['CMake', 'Make', 'GCC', 'Git', 'Mercurial', 'Subversion'],
+    Utilities: ['CMake', 'Make', 'GCC', 'Git', 'Clang', 'Mercurial', 'Subversion'],
     Servers: ['Apache', 'Nginx'],
     Virtualization: ['Docker', 'Parallels', 'VirtualBox', 'VMware Fusion'],
     SDKs: ['iOS SDK', 'Android SDK'],


### PR DESCRIPTION
Fix https://github.com/tabrindle/envinfo/issues/86.

```console
  System:
    OS: Linux 4.15 Ubuntu 19.04 (Disco Dingo)
    CPU: (36) x64 Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
    Memory: 31.36 GB / 68.69 GB
    Container: Yes
    Shell: 5.0.3 - /bin/bash
  Binaries:
    Node: 12.4.0 - /usr/local/bin/node
    Yarn: 1.16.0 - /usr/local/bin/yarn
    npm: 6.9.0 - /usr/local/bin/npm
  Utilities:
    CMake: 3.10.2 - /usr/local/bin/cmake
    Make: 4.2.1 - /usr/bin/make
    GCC: 8.3.0 - /usr/bin/gcc
    Git: 2.20.1 - /usr/bin/git
    Clang: 8.0.0-3 - /usr/bin/clang
```