### PR TITLE
Add @apollo namespace to preset

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -107,8 +107,8 @@ module.exports = {
     System: ['OS'],
     Binaries: ['Node', 'npm', 'Yarn'],
     Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-    npmPackages: '*apollo*',
-    npmGlobalPackages: '*apollo*',
+    npmPackages: '{*apollo*,@apollo/*}',
+    npmGlobalPackages: '{*apollo*,@apollo/*}',
   },
   'react-native-web': {
     System: ['OS', 'CPU'],


### PR DESCRIPTION
This will let the apollo preset capture info about the upcoming `@apollo/react-components`, `@apollo/react-hoc`, and `@apollo/react-hooks` packages. 😄 