### PR TITLE
fix: Android SDK info not working on Windows

### DIFF
--- a/src/helpers/sdks.js
+++ b/src/helpers/sdks.js
@@ -6,7 +6,7 @@ module.exports = {
   getAndroidSDKInfo: () => {
     return utils
       .run(
-        process.env.ANDROID_HOME ? '$ANDROID_HOME/tools/bin/sdkmanager --list' : 'sdkmanager --list'
+        process.env.ANDROID_HOME ? `${process.env.ANDROID_HOME}/tools/bin/sdkmanager --list` : 'sdkmanager --list'
       )
       .then(output => {
         if (!output && utils.isMacOS)

--- a/src/helpers/sdks.js
+++ b/src/helpers/sdks.js
@@ -6,7 +6,9 @@ module.exports = {
   getAndroidSDKInfo: () => {
     return utils
       .run(
-        process.env.ANDROID_HOME ? `${process.env.ANDROID_HOME}/tools/bin/sdkmanager --list` : 'sdkmanager --list'
+        process.env.ANDROID_HOME
+          ? `${process.env.ANDROID_HOME}/tools/bin/sdkmanager --list`
+          : 'sdkmanager --list'
       )
       .then(output => {
         if (!output && utils.isMacOS)


### PR DESCRIPTION
getAndroidSDKInfo was not working on Windows because $ANDROID_HOME is a Mac-specific way to use environment variables. This uses the variable from process.env instead.