### PR TITLE
feat: add babel preset

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -121,4 +121,9 @@ module.exports = {
       showNotFound: true,
     },
   },
+  babel: {
+    System: ['OS'],
+    Binaries: ['Node', 'npm', 'Yarn'],
+    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna}',
+  },
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -124,6 +124,7 @@ module.exports = {
   babel: {
     System: ['OS'],
     Binaries: ['Node', 'npm', 'Yarn'],
+    Monorepos: ['Yarn Workspaces', 'Lerna'],
     npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest}',
   },
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -124,6 +124,6 @@ module.exports = {
   babel: {
     System: ['OS'],
     Binaries: ['Node', 'npm', 'Yarn'],
-    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna}',
+    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest}',
   },
 };


### PR DESCRIPTION
This PR introduces `babel` preset and we plan to offer `npx envinfo --preset babel` in our issue template.

Example output:
```
  System:
    OS: macOS 10.15
  Binaries:
    Node: 12.11.1 - /usr/local/bin/node
    Yarn: 1.19.1 - /usr/local/bin/yarn
    npm: 6.11.3 - /usr/local/bin/npm
  npmPackages:
    @babel/core: ^7.6.0 => 7.6.0 
    @babel/plugin-proposal-class-properties: ^7.5.5 => 7.5.5 
    @babel/plugin-proposal-numeric-separator: ^7.2.0 => 7.2.0 
    @babel/plugin-proposal-private-methods: ^7.6.0 => 7.6.0 
    @babel/preset-env: ^7.6.0 => 7.6.0 
    eslint: ^6.5.1 => 6.5.1 
```