### PR TITLE
implement monorepos

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,7 @@ if (argv.help || argv._.indexOf('help') > -1) {
     --IDEs                 Get version numbers of installed IDEs
     --languages            Get version numbers of installed languages such as Java, Python, PHP, etc
     --managers             Get version numbers of installed package/dependency managers
+    --monorepos            Get monorepo tools
     --binaries             Get version numbers of node, npm, watchman, etc
     --npmPackages          Get version numbers of locally installed npm packages - glob, string, or comma delimited list
     --npmGlobalPackages    Get version numbers of globally installed npm packages

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -7,6 +7,7 @@ const databases = require('./databases');
 const ides = require('./ides');
 const languages = require('./languages');
 const managers = require('./managers');
+const monorepos = require('./monorepos');
 const sdks = require('./sdks');
 const servers = require('./servers');
 const system = require('./system');
@@ -20,6 +21,7 @@ module.exports = Object.assign({}, utils, packages, {
   ...ides,
   ...languages,
   ...managers,
+  ...monorepos,
   ...sdks,
   ...servers,
   ...system,

--- a/src/helpers/monorepos.js
+++ b/src/helpers/monorepos.js
@@ -1,0 +1,34 @@
+const utils = require('../utils');
+const path = require("path");
+
+module.exports = {
+  getYarnWorkspacesInfo: () => {
+    utils.log('trace', 'getYarnWorkspacesInfo');
+    return Promise.all([
+      utils.run('yarn -v'),
+      utils
+        .getPackageJsonByPath('package.json')
+        .then(packageJson => packageJson && 'workspaces' in packageJson),
+    ]).then(v => {
+      const name = 'Yarn Workspaces';
+      if (v[0] && v[1]) {
+        return Promise.resolve([name, v[0]]);
+      }
+      return Promise.resolve([name, 'Not Found']);
+    });
+  },
+
+  getLernaInfo: () => {
+    utils.log('trace', 'getLernaInfo');
+    return Promise.all([
+      utils.getPackageJsonByName('lerna').then(packageJson => packageJson && packageJson.version),
+      utils.fileExists(path.join(process.cwd(), 'lerna.json')),
+    ]).then(v => {
+      const name = 'Lerna';
+      if (v[0] && v[1]) {
+        return Promise.resolve([name, v[0]])
+      }
+      return Promise.resolve([name, 'Not Found'])
+    });
+  },
+};

--- a/src/helpers/monorepos.js
+++ b/src/helpers/monorepos.js
@@ -1,5 +1,5 @@
 const utils = require('../utils');
-const path = require("path");
+const path = require('path');
 
 module.exports = {
   getYarnWorkspacesInfo: () => {
@@ -26,9 +26,9 @@ module.exports = {
     ]).then(v => {
       const name = 'Lerna';
       if (v[0] && v[1]) {
-        return Promise.resolve([name, v[0]])
+        return Promise.resolve([name, v[0]]);
       }
-      return Promise.resolve([name, 'Not Found'])
+      return Promise.resolve([name, 'Not Found']);
     });
   },
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -59,6 +59,7 @@ module.exports = {
       'Safari',
       'Safari Technology Preview',
     ],
+    Monorepos: ['Yarn Workspaces', 'Lerna'],
     npmPackages: null,
     npmGlobalPackages: null,
   },


### PR DESCRIPTION
Implement `monorepos` support for #126. The version of `Yarn Workspaces` is the one of `Yarn`, and `Lerna` is straightforward.

Example output on babel repository.

```sh
$  envinfo --monorepos --showNotFound

  Monorepos:
    Yarn Workspaces: Not Found
    Lerna: 3.16.4
```