### PR TITLE
remove unnecessary fs calls

### DIFF
--- a/src/helpers/sdks.js
+++ b/src/helpers/sdks.js
@@ -19,19 +19,25 @@ module.exports = {
         const sdkmanager = utils.parseSDKManagerOutput(output);
         const getNdkVersionFromPath = ndkDir => {
           const metaPath = path.join(ndkDir, 'source.properties');
-          if (fs.existsSync(metaPath)) {
-            const contents = fs.readFileSync(metaPath).toString();
-            const split = contents.split('\n');
-            for (let i = 0; i < split.length; i += 1) {
-              const splits = split[i].split('=');
-              if (splits.length === 2) {
-                if (splits[0].trim() === 'Pkg.Revision') {
-                  return splits[1].trim();
-                }
+          let contents;
+          try {
+            contents = fs.readFileSync(metaPath, 'utf8');
+          } catch (err) {
+            if (err.code === 'ENOENT') {
+              return undefined;
+            }
+            throw err;
+          }
+
+          const split = contents.split('\n');
+          for (let i = 0; i < split.length; i += 1) {
+            const splits = split[i].split('=');
+            if (splits.length === 2) {
+              if (splits[0].trim() === 'Pkg.Revision') {
+                return splits[1].trim();
               }
             }
           }
-
           return undefined;
         };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,15 +39,12 @@ const fileExists = filePath => {
 
 const readFile = filePath => {
   return new Promise(fileResolved => {
-    if (!filePath) fileResolved(null);
     fs.readFile(filePath, 'utf8', (err, file) => (file ? fileResolved(file) : fileResolved(null)));
   });
 };
 
 const requireJson = filePath => {
-  return fileExists(filePath)
-    .then(readFile)
-    .then(file => (file ? JSON.parse(file) : null));
+  return readFile(filePath).then(file => (file ? JSON.parse(file) : null));
 };
 
 const versionRegex = /\d+\.[\d+|.]+/g;


### PR DESCRIPTION
In this PR we removed i) `fs.stat` call before` fs.readFile` and ii) `fs.existsSync` call before `fs.readFileSync`.

The first call pattern would introduce race condition because `fs.stat` is asynchronous, which means other process could change the file's state between `fs.stat` and `fs.readFile`.

The second call pattern introduces duplicate IO operations. `fs.readFileSync` will throw `ENOENT` when file does not exists and later this error will be caught and converted to `null`. Therefore it is unnecessary to call `fileExists` before `readFile`.
