### PR TITLE
fix rust version info

### DIFF
--- a/src/helpers/languages.js
+++ b/src/helpers/languages.js
@@ -86,13 +86,10 @@ module.exports = {
 
   getRustInfo: () => {
     utils.log('trace', 'getRustInfo');
-    if (utils.isMacOS || utils.isLinux) {
-      return Promise.all([
-        utils.run('rustup --version').then(utils.findVersion),
-        utils.run('which rustup'),
-      ]).then(v => utils.determineFound('Rust', v[0], v[1]));
-    }
-    return Promise.resolve(['Rust', 'N/A']);
+    return Promise.all([
+      utils.run('rustc --version').then(utils.findVersion),
+      utils.run('which rustc'),
+    ]).then(v => utils.determineFound('Rust', v[0], v[1]));
   },
 
   getScalaInfo: () => {


### PR DESCRIPTION
Fix #136

on my Windows 10:

```console
  Languages:
    Go: 1.13.4 - C:\Go\bin\go.EXE
    Java: 1.8.0_201 - C:\Program Files\Java\jdk1.8.0_201\bin\javac.EXE
    Perl: 5.26.2 - C:\Program Files\Git\usr\bin\perl.EXE
    Python: 3.8.0 - C:\Python38\python.EXE
    R: 3.6.0 - C:\Program Files\R\R-3.6.0\bin\x64\R.EXE
    Rust: 1.39.0 - C:\ProgramData\chocolatey\bin\rustc.EXE

```