### PR TITLE
fix --npmGlobalPackages on windows

### DIFF
--- a/src/packages.js
+++ b/src/packages.js
@@ -157,7 +157,13 @@ function getnpmGlobalPackages(packages, options) {
           new Promise((resolve, reject) =>
             glob(
               // sub packageGlob in to only get globbed packages if not null
-              path.join(prefix, 'lib', 'node_modules', packageGlob || '{*,@*/*}', 'package.json'),
+              path.join(
+                prefix,
+                utils.isWindows ? '' : 'lib',
+                'node_modules',
+                packageGlob || '{*,@*/*}',
+                'package.json'
+              ),
               (err, files) => {
                 if (!err) resolve(files);
                 reject(err);


### PR DESCRIPTION
Fix: https://github.com/tabrindle/envinfo/issues/143

[npm-folders: Node Modules](https://docs.npmjs.com/files/folders.html#node-modules)
> Global installs on Unix systems go to {prefix}/lib/node_modules. Global installs on Windows go to {prefix}/node_modules (that is, no lib folder.)