### PR TITLE
add edge support on macos

### DIFF
--- a/src/helpers/browsers.js
+++ b/src/helpers/browsers.js
@@ -49,6 +49,10 @@ module.exports = {
       edgeVersion = utils
         .run('powershell get-appxpackage Microsoft.MicrosoftEdge')
         .then(utils.findVersion);
+    } else if (utils.isMacOS) {
+      edgeVersion = utils.getDarwinApplicationVersion(
+        utils.browserBundleIdentifiers['Microsoft Edge']
+      );
     } else {
       edgeVersion = Promise.resolve('N/A');
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,6 +120,7 @@ module.exports = {
     Firefox: 'org.mozilla.firefox',
     'Firefox Developer Edition': 'org.mozilla.firefoxdeveloperedition',
     'Firefox Nightly': 'org.mozilla.nightly',
+    'Microsoft Edge': 'com.microsoft.edgemac',
     Safari: 'com.apple.Safari',
     'Safari Technology Preview': 'com.apple.SafariTechnologyPreview',
   },


### PR DESCRIPTION
adding support to detect microsoft edge on macos.  tested on macos `10.15.3`.

`node src/cli.js --browsers` gives me the following output:

```
  Browsers:
    Chrome: 80.0.3987.122
    Chrome Canary: 82.0.4069.0
    Edge: 80.0.361.57
    Firefox: 72.0.2
    Safari: 13.0.5
```