### PR TITLE
update yarn lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,6 +4982,11 @@ prettier-eslint@^8.5.0:
     typescript-eslint-parser "^16.0.0"
     vue-eslint-parser "^2.0.2"
 
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
 prettier@^1.7.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"


### PR DESCRIPTION
I'm not sure why but on two of my PRs https://github.com/tabrindle/envinfo/pull/161 & https://github.com/tabrindle/envinfo/pull/152, the travis build fails on every node version with this error:

```
6.10s$ yarn --frozen-lockfile
yarn install v1.15.2
[1/5] Validating package.json...
[2/5] Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command "eval yarn --frozen-lockfile " failed. Retrying, 2 of 3.
yarn install v1.15.2
[1/5] Validating package.json...
[2/5] Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command "eval yarn --frozen-lockfile " failed. Retrying, 3 of 3.
yarn install v1.15.2
[1/5] Validating package.json...
[2/5] Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command "eval yarn --frozen-lockfile " failed 3 times.
The command "yarn --frozen-lockfile" failed and exited with 1 during .
Your build has been stopped.
```

When I run `yarn install` on `master`, it updates the lock file and the travis builds of my fork pass.