### PR TITLE
build: ignore engines errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+install: yarn install --frozen-lockfile --ignore-engines
 language: node_js
 node_js:
   - "6"


### PR DESCRIPTION
Here's a passing build. Yarn lets us [ignore the engines errors](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-ignore-engines) which I think is the best route to take here given the build is still successful.

Fixes #172 