### PR TITLE
fix(presets): find Playwright NPM packages

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -144,6 +144,6 @@ module.exports = {
     System: ['OS', 'Memory', 'Container'],
     Binaries: ['Node', 'Yarn', 'npm'],
     Languages: ['Bash'],
-    npmPackages: '{playwright*}',
+    npmPackages: 'playwright*',
   },
 };


### PR DESCRIPTION
It was not working before, oriented at the Babel examples but maybe I don't understand glob.

See here for before and after: https://github.com/microsoft/playwright/pull/2237#issuecomment-682379103