### PR TITLE
preset(playwright): add new packages

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -146,6 +146,6 @@ module.exports = {
     System: ['OS', 'Memory', 'Container'],
     Binaries: ['Node', 'Yarn', 'npm'],
     Languages: ['Bash'],
-    npmPackages: 'playwright*',
+    npmPackages: '{playwright*,@playwright/*}',
   },
 };


### PR DESCRIPTION
Playwright now has some additional supporting packages published under the `@playwright/*` npm scope (e.g. https://www.npmjs.com/package/@playwright/test from the docs https://playwright.dev/docs/api/class-test).