### PR TITLE
fix: get the first app

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,9 @@ const findDarwinApplication = id => {
   log('trace', 'findDarwinApplication', id);
   const command = `mdfind "kMDItemCFBundleIdentifier=='${id}'"`;
   log('trace', command);
-  return run(command).then(v => v.replace(/(\s)/g, '\\ '));
+  return run(command).then(v => {
+    return v.split('\n')[0].replace(/(\s)/g, '\\ ');
+  });
 };
 
 const generatePlistBuddyCommand = (appPath, options) => {


### PR DESCRIPTION
I get multiple output of this:
envinfo git:(main) `mdfind kMDItemCFBundleIdentifier=='com.google.Chrome'
`
`/Applications/Google Chrome.app`
`/System/Volumes/Data/Previous Content/Recovered Items/Applications/Google Chrome.app`

and i can't get the version of chrome

➜  envinfo git:(fix/multi-output) /usr/libexec/PlistBuddy -c "Print ApplicationProperties:CFBundleShortVersionString" /Applications/Google\ Chrome.app\ /System/Volumes/Data/Previous\ Content/Recovered\ Items/Applications/Google\ Chrome.app/Contents/Info.plist
File Doesn't Exist, Will Create: /Applications/Google Chrome.app /System/Volumes/Data/Previous Content/Recovered Items/Applications/Google Chrome.app/Contents/Info.plist
Print: Entry, "ApplicationProperties:CFBundleShortVersionString", Does Not Exist