### PR TITLE
docs: add FakerJS to ISSUE_TEMPLATE users

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ envinfo is used in the ISSUE_TEMPLATE of:
 -   [styled-components](https://github.com/styled-components/styled-components)
 -   [Jest](https://github.com/facebook/jest)
 -   [Apollo Client](https://github.com/apollographql/apollo-client)
+-   [FakerJS](https://github.com/faker-js/faker)
 
 ## Alternatives
 


### PR DESCRIPTION
# Description

I have included [FakerJS](https://fakerjs.dev/) in the list of libraries that utilize `envinfo` in their ISSUE_TEMPLATES. [Our Bug Report Template recommends using your library](https://github.com/faker-js/faker/blob/3f70b0ac31520885c39fd79d18750e2701a22b28/.github/ISSUE_TEMPLATE/bug_report.yml?plain=1#L69).

Should you decide against adding us to the list, please feel free to close this PR. I believe that having community cross-references could be mutually beneficial for both libraries in terms of visibility.