### PR TITLE
feat: Update Babel preset

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -150,7 +150,8 @@ module.exports = {
     System: ['OS'],
     Binaries: ['Node', 'npm', 'Yarn', 'pnpm', 'bun'],
     Monorepos: ['Yarn Workspaces', 'Lerna'],
-    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest,next,rollup}',
+    npmPackages:
+      '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest,next,rollup}',
   },
   playwright: {
     System: ['OS', 'CPU', 'Memory', 'Container'],

--- a/src/presets.js
+++ b/src/presets.js
@@ -150,7 +150,7 @@ module.exports = {
     System: ['OS'],
     Binaries: ['Node', 'npm', 'Yarn', 'pnpm', 'bun'],
     Monorepos: ['Yarn Workspaces', 'Lerna'],
-    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest}',
+    npmPackages: '{*babel*,@babel/*,eslint,webpack,create-react-app,react-native,lerna,jest,next,rollup}',
   },
   playwright: {
     System: ['OS', 'CPU', 'Memory', 'Container'],


### PR DESCRIPTION
Added next and rollup to `npmPackages` as next bundled `@babel/core` and `rollup` can work with `@babel/core` via `@rollup-plugin/babel`.